### PR TITLE
select('*')の検証

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_one :profile, class_name: 'User::Profile', dependent: :destroy
+end

--- a/app/models/user/profile.rb
+++ b/app/models/user/profile.rb
@@ -1,0 +1,3 @@
+class User::Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20230803142125_create_users.rb
+++ b/db/migrate/20230803142125_create_users.rb
@@ -1,0 +1,8 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false, index: { unique: true }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230803142402_create_user_profiles.rb
+++ b/db/migrate/20230803142402_create_user_profiles.rb
@@ -1,0 +1,10 @@
+class CreateUserProfiles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,31 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_08_03_142402) do
+  create_table "user_profiles", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_profiles_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "user_profiles", "users"
+end


### PR DESCRIPTION
# Rails7.0.6

https://github.com/rails/rails/tree/v7.0.6

# 業務で遭遇したコード

https://github.com/speee/dx-ieul-core/issues/15561#issuecomment-1631860725

# データ作成

```rb
user = User.create(id: 1, email: 'hoge@example.com')
user.build_profile(id: 2, first_name: 'first', last_name:'last')
```

# 再現コマンド

```rb
User.joins(:profile).select('*').first
```

# 結果

## Expect

userモデルを取得したいので `id: 1` が取得されたい。
```
#<User:0x0000000114db6388
 id: 1,
 email: "hoge@example.com",
 created_at:
  Thu, 03 Aug 2023 14:30:23.040019000 UTC +00:00,
 updated_at:
  Thu, 03 Aug 2023 14:30:23.040019000 UTC +00:00>
```

## Actual
実際は `id: 2` が取得される。`id: 2` のuser_profileをjoinしているため、user_profileのidが取得されてしまっている。
```
#<User:0x0000000114db6388
 id: 2,
 email: "hoge@example.com",
 created_at:
  Thu, 03 Aug 2023 14:30:23.040019000 UTC +00:00,
 updated_at:
  Thu, 03 Aug 2023 14:30:23.040019000 UTC +00:00>
```

発行されるSQLを見るとこう。
```rb
User.joins(:profile).select('*').to_sql
=> "SELECT * FROM users INNER JOIN user_profiles ON user_profiles.user_id = users.id"
```

# 方針

railsのバグではなく、`select('*')` を使っている開発者が悪いのではあるが、知らないと気づかないので同じカラムが存在する場合は警告を出すようにしたい。破壊的変更にしたくないので。
まずはActiveRecordのロジックがどのようになっているのかを調べる。

# 開発tips

よく使うコマンドなどをここに置く。

## メソッドの場所を調べるとき

```
hoge.method(:method_name).source_location
```

## debuggerを動かすとき

`binding.irb` を仕込んでから止まった状態で `next` と `step` 
`next` はステップオーバー。
`step` はステップイン。

## active_recordのテスト実行

`cd active_record` をした状態で

単体のメソッドをテストする。
```
bundle exec ruby -Itest test/cases/relation/select_test.rb -n test_select_duplicate_column_name
```

全体をテストする。
```
bundle exec rake sqlite3:test
```